### PR TITLE
tildă și backtick la tastatură PC

### DIFF
--- a/Romanian - Programmers 2.keylayout
+++ b/Romanian - Programmers 2.keylayout
@@ -96,7 +96,7 @@
 			<key code="47" output="."/>
 			<key code="48" output="&#x0009;"/>
 			<key code="49" action=" "/>
-			<key code="50" output="\"/>
+			<key code="50" output="`"/>
 			<key code="51" output="&#x0008;"/>
 			<key code="53" output="&#x001B;"/>
 			<key code="55" output=""/>
@@ -205,7 +205,7 @@
 			<key code="47" output="&#x003E;"/>
 			<key code="48" output="&#x0009;"/>
 			<key code="49" output=" "/>
-			<key code="50" output="|"/>
+			<key code="50" output="~"/>
 			<key code="51" output="&#x0008;"/>
 			<key code="53" output="&#x001B;"/>
 			<key code="64" output="&#x0010;"/>


### PR DESCRIPTION
Modific butonul 50 care îl duplică pe 42, și îl mapez pe backtick și tildă, pentru a funcționa și cu tastaturile PC cu aranjamentul US.