### PR TITLE
Numeric Keypad Decimal Separator

### DIFF
--- a/Romanian - Programmers 1.keylayout
+++ b/Romanian - Programmers 1.keylayout
@@ -103,7 +103,7 @@
 			<key code="56" output=""/>
 			<key code="57" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -209,7 +209,7 @@
 			<key code="51" output="&#x0008;"/>
 			<key code="53" output="&#x001B;"/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -318,7 +318,7 @@
 			<key code="56" output=""/>
 			<key code="58" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -424,7 +424,7 @@
 			<key code="51" output="&#x0008;"/>
 			<key code="53" output="&#x001B;"/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -531,7 +531,7 @@
 			<key code="53" output="&#x001B;"/>
 			<key code="56" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -727,7 +727,7 @@
 			<key code="51" output="&#x0008;"/>
 			<key code="53" output="&#x001B;"/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -836,7 +836,7 @@
 			<key code="56" output=""/>
 			<key code="58" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -944,7 +944,7 @@
 			<key code="56" output=""/>
 			<key code="57" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>

--- a/Romanian - Programmers 2.keylayout
+++ b/Romanian - Programmers 2.keylayout
@@ -103,7 +103,7 @@
 			<key code="56" output=""/>
 			<key code="57" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -209,7 +209,7 @@
 			<key code="51" output="&#x0008;"/>
 			<key code="53" output="&#x001B;"/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -318,7 +318,7 @@
 			<key code="56" output=""/>
 			<key code="58" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -424,7 +424,7 @@
 			<key code="51" output="&#x0008;"/>
 			<key code="53" output="&#x001B;"/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -531,7 +531,7 @@
 			<key code="53" output="&#x001B;"/>
 			<key code="56" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -727,7 +727,7 @@
 			<key code="51" output="&#x0008;"/>
 			<key code="53" output="&#x001B;"/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -836,7 +836,7 @@
 			<key code="56" output=""/>
 			<key code="58" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>
@@ -944,7 +944,7 @@
 			<key code="56" output=""/>
 			<key code="57" output=""/>
 			<key code="64" output="&#x0010;"/>
-			<key code="65" output="."/>
+			<key code="65" output=","/>
 			<key code="66" output="&#x001D;"/>
 			<key code="67" output="*"/>
 			<key code="69" output="+"/>


### PR DESCRIPTION
Replaced "." with "," as numpad decimal separator.